### PR TITLE
Fixing deprecation notice

### DIFF
--- a/templates/cucumber/Gemfile.tt
+++ b/templates/cucumber/Gemfile.tt
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development do
   gem 'cucumber'

--- a/templates/minitest/Gemfile.tt
+++ b/templates/minitest/Gemfile.tt
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development do
   gem 'minitest'

--- a/templates/minitest_spec/Gemfile.tt
+++ b/templates/minitest_spec/Gemfile.tt
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development do
   gem 'minitest'

--- a/templates/rspec/Gemfile.tt
+++ b/templates/rspec/Gemfile.tt
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development do
   gem 'rspec'

--- a/templates/testunit/Gemfile.tt
+++ b/templates/testunit/Gemfile.tt
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 group :development do
   gem 'test-unit'


### PR DESCRIPTION
Using source :rubygems is now deprecated in favor of source 'https://rubygems.org'
