### PR TITLE
Add cmd option to Guardfile

### DIFF
--- a/templates/rspec/Guardfile
+++ b/templates/rspec/Guardfile
@@ -1,4 +1,4 @@
-guard 'rspec' do
+guard 'rspec', cmd: 'rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec/" }


### PR DESCRIPTION
This option is required as of a recent version of guard-rspec.
